### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/SouthernGameDevs/1b50f737-dc0e-4eb8-9eee-aa9dd93a45e7/77d8378f-3063-4cf4-9eeb-91b38038283c/_apis/work/boardbadge/b404e1c7-7b37-43aa-b439-e04c9fb950df)](https://dev.azure.com/SouthernGameDevs/1b50f737-dc0e-4eb8-9eee-aa9dd93a45e7/_boards/board/t/77d8378f-3063-4cf4-9eeb-91b38038283c/Microsoft.RequirementCategory)
 # TestingAzure


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/SouthernGameDevs/1b50f737-dc0e-4eb8-9eee-aa9dd93a45e7/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.